### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/bin/josh-proxy.rs
+++ b/src/bin/josh-proxy.rs
@@ -158,7 +158,7 @@ fn async_fetch(
     password: &str,
     namespace: &str,
     remote_url: String,
-) -> Box<Future<Item = Result<PathBuf, git2::Error>, Error = hyper::Error>> {
+) -> Box<dyn Future<Item = Result<PathBuf, git2::Error>, Error = hyper::Error>> {
     let br_path = http.base_path.clone();
     base_repo::create_local(&br_path);
 
@@ -260,7 +260,7 @@ fn call_service(
     service: &HttpService,
     req: Request,
     namespace: &str,
-) -> Box<Future<Item = Response, Error = hyper::Error>> {
+) -> Box<dyn Future<Item = Response, Error = hyper::Error>> {
     let backward_maps = service.backward_maps.clone();
 
     let path = {
@@ -410,7 +410,7 @@ fn call_service(
                                  path: PathBuf,
                                  pathinfo: &str,
                                  handle: &tokio_core::reactor::Handle|
-     -> Box<Future<Item = Response, Error = hyper::Error>> {
+     -> Box<dyn Future<Item = Response, Error = hyper::Error>> {
         println!("CALLING git-http backend {:?} {:?}", path, pathinfo);
         let mut cmd = Command::new("git");
         cmd.arg("http-backend");
@@ -451,7 +451,7 @@ fn call_service(
             br_url,
         )
         .and_then(
-            move |view_repo| -> Box<Future<Item = Response, Error = hyper::Error>> {
+            move |view_repo| -> Box<dyn Future<Item = Response, Error = hyper::Error>> {
                 let path = ok_or!(view_repo, {
                     println!("wrong credentials");
                     return Box::new(futures::future::ok(respond_unauthorized()));
@@ -476,7 +476,7 @@ impl Service for HttpService {
     type Response = Response;
     type Error = hyper::Error;
 
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
 
     fn call(&self, req: Request) -> Self::Future {
         let rid: usize = random();

--- a/src/bin/josh-test-server.rs
+++ b/src/bin/josh-test-server.rs
@@ -40,7 +40,7 @@ impl Service for ServeTestGit {
     type Response = Response;
     type Error = hyper::Error;
 
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
 
     fn call(&self, req: Request) -> Self::Future {
         println!("call");

--- a/src/cgi.rs
+++ b/src/cgi.rs
@@ -22,7 +22,7 @@ pub fn do_cgi(
     req: Request,
     cmd: Command,
     handle: tokio_core::reactor::Handle,
-) -> Box<Future<Item = Response, Error = hyper::Error>> {
+) -> Box<dyn Future<Item = Response, Error = hyper::Error>> {
     trace_scoped!("do_cgi");
     let mut cmd = cmd;
     cmd.stdout(Stdio::piped());

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -52,7 +52,7 @@ pub fn rewrite(
 pub fn unapply_view(
     repo: &git2::Repository,
     backward_maps: &view_maps::ViewMaps,
-    viewobj: &views::View,
+    viewobj: &dyn views::View,
     old: git2::Oid,
     new: git2::Oid,
 ) -> UnapplyView {
@@ -136,7 +136,7 @@ pub fn new(path: &Path) -> git2::Repository {
 
 fn transform_commit(
     repo: &git2::Repository,
-    viewobj: &views::View,
+    viewobj: &dyn views::View,
     from_refsname: &str,
     to_refname: &str,
     forward_maps: &mut view_maps::ViewMaps,

--- a/src/view_maps.rs
+++ b/src/view_maps.rs
@@ -61,7 +61,7 @@ impl ViewMaps {
 
     pub fn merge(&mut self, other: &ViewMaps) {
         for (viewstr, om) in other.maps.iter() {
-            let mut m = self
+            let m = self
                 .maps
                 .entry(viewstr.to_string())
                 .or_insert_with(ViewMap::new);


### PR DESCRIPTION
With newer versions of rustc additional warnings have been added
(e.g. deprecation warnings).