### PR TITLE
Fix libraries versions in Cargo

### DIFF
--- a/josh-test-server/Cargo.toml
+++ b/josh-test-server/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 [dependencies]
 clap = "2"
 futures = "*"
-tokio = {version = "*", features = ["full"] }
+tokio = {version = "0.2.22", features = ["full"] }
 tokio-process = "*"
 tokio-io = "*"
 tokio-util = { version = "0.3.1", features=["compat"] }
-hyper = "*"
+hyper = "0.13"
 hyper_cgi = "*"
 mime = "*"
 base64 = "*"


### PR DESCRIPTION
 To fix the failing build due to incompatible versions of tokio
 and hyper used in  hyper_cgi and this, fix the versions in Cargo.toml