### PR TITLE
Use new algorithm for workspace unapply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "cookie"
@@ -765,9 +765,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libgit2-sys"
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
 ]
@@ -1458,18 +1458,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1544,9 +1544,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "socket2"
@@ -1626,9 +1626,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8833e20724c24de12bbaba5ad230ea61c3eafb05b881c7c9d3cfe8638b187e68"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1751,9 +1751,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes",
  "fnv",
@@ -1993,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -302,7 +302,7 @@ async fn do_filter(
         let _e = s.enter();
         tracing::trace!("in do_filter worker");
         let repo = git2::Repository::init_bare(&repo_path)?;
-        let filter = josh::filters::parse(&filter_spec);
+        let filter = josh::filters::parse(&filter_spec)?;
         let filter_spec = filter.filter_spec();
         let mut from_to = josh::housekeeping::default_from_to(
             &repo,
@@ -427,7 +427,7 @@ async fn call_service(
                 let repo = git2::Repository::init_bare(&serv.repo_path)?;
                 josh::housekeeping::get_info(
                     &repo,
-                    &*josh::filters::parse(&parsed_url.filter),
+                    &*josh::filters::parse(&parsed_url.filter)?,
                     &parsed_url.upstream_repo,
                     &headref,
                     forward_maps.clone(),

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -772,7 +772,7 @@ fn main() {
         }
     }
 
-    let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false);
+    /* let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false); */
 
     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
         .with_service_name(
@@ -789,8 +789,8 @@ fn main() {
     let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
     let subscriber = tracing_subscriber::Registry::default()
-        .with(telemetry_layer)
-        .with(fmt_layer);
+        .with(telemetry_layer);
+        /* .with(fmt_layer); */
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("can't set_global_default");

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -788,9 +788,9 @@ fn main() {
 
     let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
-    let subscriber = tracing_subscriber::Registry::default()
-        .with(telemetry_layer);
-        /* .with(fmt_layer); */
+    let subscriber =
+        tracing_subscriber::Registry::default().with(telemetry_layer);
+    /* .with(fmt_layer); */
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("can't set_global_default");

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -84,7 +84,7 @@ pub fn process_repo_update(
         oid
     };
 
-    let filterobj = josh::filters::parse(&filter_spec);
+    let filterobj = josh::filters::parse(&filter_spec)?;
     let new_oid = git2::Oid::from_str(&new)?;
     let backward_new_oid = {
         tracing::debug!("=== MORE");

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -21,16 +21,10 @@ fn baseref_and_options(
     return Ok((baseref, push_to, options));
 }
 
-#[tracing::instrument(skip(_forward_maps, backward_maps, credential_store))]
+#[tracing::instrument(skip(credential_store))]
 pub fn process_repo_update(
     credential_store: std::sync::Arc<std::sync::RwLock<CredentialStore>>,
     repo_update: std::collections::HashMap<String, String>,
-    _forward_maps: std::sync::Arc<
-        std::sync::RwLock<josh::filter_cache::FilterCache>,
-    >,
-    backward_maps: std::sync::Arc<
-        std::sync::RwLock<josh::filter_cache::FilterCache>,
-    >,
 ) -> Result<String, josh::JoshError> {
     let refname = repo_update.get("refname").ok_or(josh::josh_error(""))?;
     let filter_spec =
@@ -93,7 +87,6 @@ pub fn process_repo_update(
 
         match josh::scratch::unapply_filter(
             &repo,
-            backward_maps,
             &*filterobj,
             unfiltered_old,
             old,

--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -91,21 +91,20 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
 
         let mut filterobj = josh::filters::parse(&filter_spec)?;
 
-        let pres = filterobj.prefixes();
-
-        if args.is_present("infofile") {
-            for (p, v) in pres.iter() {
-                filterobj = josh::build_chain(
-                    filterobj,
-                    josh::filters::parse(&format!(
-                        ":INFO={},commit=#sha1,tree=#tree,src={},filter={}",
-                        p,
-                        &src,
-                        v.replace(":", "<colon>").replace(",", "<comma>")
-                    ))?,
-                );
-            }
-        }
+        /* if args.is_present("infofile") { */
+        /*     let pres = filterobj.prefixes(); */
+        /*     for (p, v) in pres.iter() { */
+        /*         filterobj = josh::build_chain( */
+        /*             filterobj, */
+        /*             josh::filters::parse(&format!( */
+        /*                 ":INFO={},commit=#sha1,tree=#tree,src={},filter={}", */
+        /*                 p, */
+        /*                 &src, */
+        /*                 v.replace(":", "<colon>").replace(",", "<comma>") */
+        /*             ))?, */
+        /*         ); */
+        /*     } */
+        /* } */
 
         let reverse = args.is_present("reverse");
         let check_permissions = args.is_present("check-permission");

--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -1,4 +1,4 @@
-/* #![deny(warnings)] */
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_use]
@@ -98,7 +98,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
                 filterobj = josh::build_chain(
                     filterobj,
                     josh::filters::parse(&format!(
-                        ":info={},commit=#sha1,tree=#tree,src={},filter={}",
+                        ":INFO={},commit=#sha1,tree=#tree,src={},filter={}",
                         p,
                         &src,
                         v.replace(":", "<colon>").replace(",", "<comma>")
@@ -112,7 +112,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
 
         if args.is_present("squash") {
             filterobj = josh::build_chain(
-                josh::filters::parse(&format!(":cutoff={}", &src))?,
+                josh::filters::parse(&format!(":CUTOFF={}", &src))?,
                 filterobj,
             );
         }
@@ -218,7 +218,6 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
                     repo.reference(&src, rewritten, true, "unapply_filter")?;
                 }
                 _ => {
-                    /* debug!("rewritten ERROR"); */
                     return Ok(1);
                 }
             }

--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -91,21 +91,6 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
 
         let mut filterobj = josh::filters::parse(&filter_spec)?;
 
-        /* if args.is_present("infofile") { */
-        /*     let pres = filterobj.prefixes(); */
-        /*     for (p, v) in pres.iter() { */
-        /*         filterobj = josh::build_chain( */
-        /*             filterobj, */
-        /*             josh::filters::parse(&format!( */
-        /*                 ":INFO={},commit=#sha1,tree=#tree,src={},filter={}", */
-        /*                 p, */
-        /*                 &src, */
-        /*                 v.replace(":", "<colon>").replace(",", "<comma>") */
-        /*             ))?, */
-        /*         ); */
-        /*     } */
-        /* } */
-
         let reverse = args.is_present("reverse");
         let check_permissions = args.is_present("check-permission");
 

--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -89,7 +89,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
 
         let filter_spec = caps.name("spec").unwrap().as_str().trim().to_owned();
 
-        let mut filterobj = josh::filters::parse(&filter_spec);
+        let mut filterobj = josh::filters::parse(&filter_spec)?;
 
         let pres = filterobj.prefixes();
 
@@ -102,7 +102,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
                         p,
                         &src,
                         v.replace(":", "<colon>").replace(",", "<comma>")
-                    )),
+                    ))?,
                 );
             }
         }
@@ -112,16 +112,16 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
 
         if args.is_present("squash") {
             filterobj = josh::build_chain(
-                josh::filters::parse(&format!(":cutoff={}", &src)),
+                josh::filters::parse(&format!(":cutoff={}", &src))?,
                 filterobj,
             );
         }
 
         if check_permissions {
             filterobj =
-                josh::build_chain(josh::filters::parse(":DIRS"), filterobj);
+                josh::build_chain(josh::filters::parse(":DIRS")?, filterobj);
             filterobj =
-                josh::build_chain(filterobj, josh::filters::parse(":FOLD"));
+                josh::build_chain(filterobj, josh::filters::parse(":FOLD")?);
         }
 
         let t = if reverse {

--- a/src/filter_parser.pest
+++ b/src/filter_parser.pest
@@ -3,7 +3,7 @@ CMD_START = _{(":"|"!")}
 CMD_END = _{("="|"/")}
 
 
-filter_spec = { (filter | filter_noarg)* }
+filter_spec = { (filter | filter_noarg)+ }
 
 filter = { CMD_START ~ cmd ~ CMD_END ~ (argument ~ ("," ~ argument)*)? }
 
@@ -13,9 +13,9 @@ argument = { (!(CMD_START | NEWLINE | ",") ~ ANY)+ }
 
 cmd = { (!(CMD_END | NEWLINE | CMD_START) ~ ANY)* }
 
-workspace_file = { NEWLINE* ~ file_entry? ~ (NEWLINE+ ~ file_entry)* ~ NEWLINE* ~ EOI }
+workspace_file = { NEWLINE* ~ (filter_spec|file_entry)? ~ (NEWLINE+ ~ (filter_spec|file_entry))* ~ NEWLINE* ~ EOI }
 
 file_entry = { dst_path ~ ("=" ~ filter_spec)? }
 
 dst_path = @{ path ~ ("/" ~ path)* }
-path = @{ (!("=" | "/" | WHITESPACE | NEWLINE) ~ ANY)+ }
+path = @{ (!("=" | "/" | CMD_START | WHITESPACE | NEWLINE) ~ ANY)+ }

--- a/src/filter_parser.pest
+++ b/src/filter_parser.pest
@@ -13,8 +13,9 @@ argument = { (!(CMD_START | NEWLINE | ",") ~ ANY)+ }
 
 cmd = { (!(CMD_END | NEWLINE | CMD_START) ~ ANY)* }
 
-workspace_file = { NEWLINE* ~ file_entry ~ (NEWLINE+ ~ file_entry)* }
+workspace_file = { NEWLINE* ~ file_entry? ~ (NEWLINE+ ~ file_entry)* ~ NEWLINE* ~ EOI }
 
 file_entry = { dst_path ~ ("=" ~ filter_spec)? }
 
-dst_path = @{ (!("=" | WHITESPACE | NEWLINE) ~ ANY)+ }
+dst_path = @{ path ~ ("/" ~ path)* }
+path = @{ (!("=" | "/" | WHITESPACE | NEWLINE) ~ ANY)+ }

--- a/src/housekeeping.rs
+++ b/src/housekeeping.rs
@@ -204,8 +204,7 @@ pub fn get_info(
 
     let mut meta = std::collections::HashMap::new();
     meta.insert("sha1".to_owned(), "".to_owned());
-    let filtered =
-        filter.apply_to_commit(&repo, &commit, &mut fm, &mut bm, &mut meta)?;
+    let filtered = filter.apply_to_commit(&repo, &commit, &mut fm, &mut bm)?;
 
     let parent_ids = |commit: &git2::Commit| {
         let pids: Vec<_> = commit

--- a/src/housekeeping.rs
+++ b/src/housekeeping.rs
@@ -278,7 +278,7 @@ pub fn refresh_known_filters(
 
             updated_count += scratch::apply_filter_to_refs(
                 &repo,
-                &*filters::parse(&filter_spec),
+                &*filters::parse(&filter_spec)?,
                 &refs,
                 &mut fm,
                 &mut bm,

--- a/src/housekeeping.rs
+++ b/src/housekeeping.rs
@@ -3,7 +3,6 @@ use git2;
 use super::*;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
-use std::sync::{Arc, RwLock};
 use tracing::{info, span, Level};
 
 pub type KnownViews = BTreeMap<String, BTreeSet<String>>;
@@ -186,13 +185,11 @@ pub fn get_info(
     filter: &dyn filters::Filter,
     upstream_repo: &str,
     headref: &str,
-    forward_maps: Arc<RwLock<filter_cache::FilterCache>>,
-    backward_maps: Arc<RwLock<filter_cache::FilterCache>>,
 ) -> JoshResult<String> {
     let _trace_s = span!(Level::TRACE, "get_info");
 
-    let mut bm = filter_cache::new_downstream(&backward_maps);
-    let mut fm = filter_cache::new_downstream(&forward_maps);
+    let mut bm = filter_cache::new_downstream(&super::filter_cache::backward());
+    let mut fm = filter_cache::new_downstream(&super::filter_cache::forward());
 
     let obj = repo.revparse_single(&format!(
         "refs/josh/upstream/{}/{}",
@@ -204,7 +201,7 @@ pub fn get_info(
 
     let mut meta = std::collections::HashMap::new();
     meta.insert("sha1".to_owned(), "".to_owned());
-    let filtered = filter.apply_to_commit(&repo, &commit, &mut fm, &mut bm)?;
+    let filtered = filter.apply_to_commit(&repo, &commit)?;
 
     let parent_ids = |commit: &git2::Commit| {
         let pids: Vec<_> = commit
@@ -246,19 +243,13 @@ pub fn get_info(
     return Ok(serde_json::to_string(&s)?);
 }
 
-#[tracing::instrument(skip(repo, forward_maps, backward_maps))]
+#[tracing::instrument(skip(repo))]
 pub fn refresh_known_filters(
     repo: &git2::Repository,
     known_filters: &KnownViews,
-    forward_maps: Arc<RwLock<filter_cache::FilterCache>>,
-    backward_maps: Arc<RwLock<filter_cache::FilterCache>>,
 ) -> JoshResult<usize> {
-    let mut total = 0;
     for (upstream_repo, e) in known_filters.iter() {
         info!("background rebuild root: {:?}", upstream_repo);
-
-        let mut bm = filter_cache::new_downstream(&backward_maps);
-        let mut fm = filter_cache::new_downstream(&forward_maps);
 
         let mut updated_count = 0;
 
@@ -279,30 +270,15 @@ pub fn refresh_known_filters(
                 &repo,
                 &*filters::parse(&filter_spec)?,
                 &refs,
-                &mut fm,
-                &mut bm,
             )?;
         }
         info!("updated {} refs for {:?}", updated_count, upstream_repo);
-
-        total += fm.stats()["total"];
-        total += bm.stats()["total"];
-        span!(Level::TRACE, "write_lock bm").in_scope(|| {
-            let mut backward_maps = backward_maps.write().unwrap();
-            backward_maps.merge(&bm);
-        });
-        span!(Level::TRACE, "write_lock fm").in_scope(|| {
-            let mut forward_maps = forward_maps.write().unwrap();
-            forward_maps.merge(&fm);
-        });
     }
-    return Ok(total);
+    return Ok(0);
 }
 
 pub fn spawn_thread(
     repo_path: std::path::PathBuf,
-    forward_maps: Arc<RwLock<filter_cache::FilterCache>>,
-    backward_maps: Arc<RwLock<filter_cache::FilterCache>>,
     do_gc: bool,
 ) -> std::thread::JoinHandle<()> {
     let mut gc_timer = std::time::Instant::now();
@@ -314,24 +290,18 @@ pub fn spawn_thread(
             let repo = git2::Repository::init_bare(&repo_path).unwrap();
             let known_filters =
                 housekeeping::discover_filter_candidates(&repo).unwrap();
-            total += refresh_known_filters(
-                &repo,
-                &known_filters,
-                forward_maps.clone(),
-                backward_maps.clone(),
-            )
-            .unwrap_or(0);
+            total += refresh_known_filters(&repo, &known_filters).unwrap_or(0);
             if total > 1000
                 || persist_timer.elapsed()
                     > std::time::Duration::from_secs(60 * 15)
             {
                 filter_cache::persist(
-                    &*backward_maps.read().unwrap(),
+                    &*super::filter_cache::backward().read().unwrap(),
                     &repo.path().join("josh_backward_maps"),
                 )
                 .ok();
                 filter_cache::persist(
-                    &*forward_maps.read().unwrap(),
+                    &*super::filter_cache::forward().read().unwrap(),
                     &repo.path().join("josh_forward_maps"),
                 )
                 .ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+/* #![deny(warnings)] */
 #![warn(unused_extern_crates)]
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_export]

--- a/src/query.rs
+++ b/src/query.rs
@@ -110,8 +110,6 @@ impl handlebars::HelperDef for FindFilesHelper {
 struct FilterHelper {
     repo: std::sync::Arc<std::sync::Mutex<git2::Repository>>,
     headref: String,
-    forward_maps: std::sync::Mutex<super::filter_cache::FilterCache>,
-    backward_maps: std::sync::Mutex<super::filter_cache::FilterCache>,
 }
 
 impl FilterHelper {
@@ -128,12 +126,10 @@ impl FilterHelper {
         let original_commit =
             repo.find_reference(&self.headref)?.peel_to_commit()?;
         let filterobj = super::filters::parse(&filter_spec)?;
-        let filter_commit = filterobj.apply_to_commit(
-            &repo,
-            &original_commit,
-            &mut *&mut self.forward_maps.lock()?,
-            &mut *&mut self.backward_maps.lock()?,
-        )?;
+
+        let filter_commit =
+            filterobj.apply_to_commit(&repo, &original_commit)?;
+
         return Ok(json!({ "sha1": format!("{}", filter_commit) }));
     }
 }
@@ -164,8 +160,6 @@ pub fn render(
     repo: git2::Repository,
     headref: &str,
     query_and_params: &str,
-    forward_maps: super::filter_cache::FilterCache,
-    backward_maps: super::filter_cache::FilterCache,
 ) -> super::JoshResult<Option<String>> {
     let mut parameters = query_and_params.split("&");
     let query = parameters.next().ok_or(super::josh_error(&format!(
@@ -233,8 +227,6 @@ pub fn render(
         Box::new(FilterHelper {
             repo: repo.clone(),
             headref: headref.to_string(),
-            forward_maps: std::sync::Mutex::new(forward_maps),
-            backward_maps: std::sync::Mutex::new(backward_maps),
         }),
     );
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -127,7 +127,7 @@ impl FilterHelper {
         let repo = self.repo.lock()?;
         let original_commit =
             repo.find_reference(&self.headref)?.peel_to_commit()?;
-        let filterobj = super::filters::parse(&filter_spec);
+        let filterobj = super::filters::parse(&filter_spec)?;
         let filter_commit = filterobj.apply_to_commit(
             &repo,
             &original_commit,

--- a/src/query.rs
+++ b/src/query.rs
@@ -133,7 +133,6 @@ impl FilterHelper {
             &original_commit,
             &mut *&mut self.forward_maps.lock()?,
             &mut *&mut self.backward_maps.lock()?,
-            &mut std::collections::HashMap::new(),
         )?;
         return Ok(json!({ "sha1": format!("{}", filter_commit) }));
     }

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -45,15 +45,15 @@ pub fn rewrite(
     )?);
 }
 
-#[tracing::instrument(skip(backward_maps, repo))]
+#[tracing::instrument(skip(repo))]
 pub fn unapply_filter(
     repo: &git2::Repository,
-    backward_maps: std::sync::Arc<std::sync::RwLock<filter_cache::FilterCache>>,
     filterobj: &dyn filters::Filter,
     unfiltered_old: git2::Oid,
     old: git2::Oid,
     new: git2::Oid,
 ) -> super::JoshResult<UnapplyFilter> {
+    let backward_maps = super::filter_cache::backward();
     let walk = {
         let mut walk = repo.revwalk()?;
         walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
@@ -177,12 +177,8 @@ fn transform_commit(
     let mut updated_count = 0;
     if let Ok(reference) = repo.revparse_single(&from_refsname) {
         let original_commit = reference.peel_to_commit()?;
-        let filter_commit = filterobj.apply_to_commit(
-            &repo,
-            &original_commit,
-            forward_maps,
-            backward_maps,
-        )?;
+        let filter_commit =
+            filterobj.apply_to_commit(&repo, &original_commit)?;
         forward_maps.set(
             &filterobj.filter_spec(),
             original_commit.id(),
@@ -239,14 +235,16 @@ fn transform_commit(
     return Ok(updated_count);
 }
 
-#[tracing::instrument(skip(repo, forward_maps, backward_maps))]
+#[tracing::instrument(skip(repo))]
 pub fn apply_filter_to_refs(
     repo: &git2::Repository,
     filterobj: &dyn filters::Filter,
     refs: &[(String, String)],
-    forward_maps: &mut filter_cache::FilterCache,
-    backward_maps: &mut filter_cache::FilterCache,
 ) -> super::JoshResult<usize> {
+    let mut backward_maps =
+        super::filter_cache::new_downstream(&super::filter_cache::backward());
+    let mut forward_maps =
+        super::filter_cache::new_downstream(&super::filter_cache::forward());
     let mut updated_count = 0;
     for (k, v) in refs {
         updated_count += transform_commit(
@@ -254,9 +252,10 @@ pub fn apply_filter_to_refs(
             &*filterobj,
             &k,
             &v,
-            forward_maps,
-            backward_maps,
+            &mut forward_maps,
+            &mut backward_maps,
         )?;
     }
+    super::filter_cache::try_merge_both(&forward_maps, &backward_maps);
     return Ok(updated_count);
 }

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -118,7 +118,7 @@ pub fn unapply_filter(
             original_parents_refs
                 .iter()
                 .map(|x| -> super::JoshResult<_> {
-                    Ok(filterobj.unapply(&repo, &tree, &x.tree()?)?)
+                    Ok(filterobj.unapply(&repo, tree.clone(), x.tree()?)?.id())
                 })
                 .collect()
         };
@@ -144,14 +144,9 @@ pub fn unapply_filter(
             )?,
             0 => {
                 tracing::debug!("unrelated history");
-                repo
-                    // 0 means the history is unrelated. Pushing it will fail if we are not
-                    // dealing with either a force push or a push with the "josh-merge" option set.
-                    .find_tree(filterobj.unapply(
-                        &repo,
-                        &tree,
-                        &empty_tree(&repo),
-                    )?)?
+                // 0 means the history is unrelated. Pushing it will fail if we are not
+                // dealing with either a force push or a push with the "josh-merge" option set.
+                filterobj.unapply(&repo, tree, empty_tree(&repo))?
             }
             parent_count => {
                 // This is a merge commit where the parents in the upstream repo

--- a/src/scratch.rs
+++ b/src/scratch.rs
@@ -5,7 +5,6 @@ use super::empty_tree;
 use super::filter_cache;
 use super::filters;
 use super::UnapplyFilter;
-use std::collections::HashMap;
 use std::collections::HashSet;
 
 fn all_equal(a: git2::Parents, b: &[&git2::Commit]) -> bool {
@@ -183,7 +182,6 @@ fn transform_commit(
             &original_commit,
             forward_maps,
             backward_maps,
-            &mut HashMap::new(),
         )?;
         forward_maps.set(
             &filterobj.filter_spec(),

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -72,10 +72,8 @@
   $ git read-tree HEAD josh/filter/libs/master josh/filter/libs/foo
   $ git commit -m "sync"
   [master *] sync (glob)
-   5 files changed, 11 insertions(+)
-   create mode 100644 a/b/.joshinfo
+   3 files changed, 3 insertions(+)
    create mode 100644 a/b/file3
-   create mode 100644 c/.joshinfo
    create mode 100644 c/file1
    create mode 100644 c/file2
   $ git reset --hard
@@ -96,16 +94,12 @@
   * initial
 
   $ cat c/.joshinfo
-  commit: * (glob)
-  filter: :/sub1
-  src: libs/master
-  tree: * (glob)
+  cat: c/.joshinfo: No such file or directory
+  [1]
 
   $ cat a/b/.joshinfo
-  commit: * (glob)
-  filter: :/sub2
-  src: libs/foo
-  tree: * (glob)
+  cat: a/b/.joshinfo: No such file or directory
+  [1]
 
 $ git show libs/master | grep $(cat c/.joshinfo | grep commit | sed 's/commit: //')
 commit * (glob)

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -16,9 +16,14 @@ Empty root commits from unrelated parts of the tree should not be included
   $ git add sub1
   $ git commit -m "add file2" 1> /dev/null
 
+  $ echo contents2 > sub1/file3
+  $ git add sub1
+  $ git commit -m "add file3" 1> /dev/null
+
   $ josh-filter master --update refs/josh/filter/master c=:/sub1
 
   $ git log refs/josh/filter/master --graph --pretty=%s
+  * add file3
   * add file2
   * add file1
 
@@ -26,37 +31,94 @@ Empty root commits from unrelated parts of the tree should not be included
   $ git ls-tree --name-only -r refs/josh/filter/master 
   c/file1
   c/file2
+  c/file3
 
   $ git checkout --orphan other
   Switched to a new branch 'other'
+  $ git reset --hard
+  $ git status
+  On branch other
+  
+  No commits yet
+  
+  nothing to commit (create/copy files and use "git add" to track)
   $ git commit --allow-empty -m "root" 1> /dev/null
+  $ git ls-tree -r HEAD
 
   $ echo contents2 > some_file
   $ git add some_file
   $ git commit -m "add some_file" 1>/dev/null
 
+  $ echo contents2 > some_other_file
+  $ git add some_other_file
+  $ git commit -m "add some_other_file" 1>/dev/null
+
   $ git checkout master
   Switched to branch 'master'
   $ git merge other --no-ff --allow-unrelated
   Merge made by the 'recursive' strategy.
-   some_file | 1 +
-   1 file changed, 1 insertion(+)
+   some_file       | 1 +
+   some_other_file | 1 +
+   2 files changed, 2 insertions(+)
    create mode 100644 some_file
+   create mode 100644 some_other_file
+
+  $ tree
+  .
+  |-- some_file
+  |-- some_other_file
+  `-- sub1
+      |-- file1
+      |-- file2
+      `-- file3
+  
+  1 directory, 5 files
 
   $ git log master --graph --pretty=%s
   *   Merge branch 'other'
   |\  
+  | * add some_other_file
   | * add some_file
   | * root
+  * add file3
   * add file2
   * add file1
 
-  $ josh-filter master --update refs/josh/filter/master c=:/sub1
 
-  $ git log refs/josh/filter/master --graph --pretty=%s
+  $ josh-filter master c=:/sub1
+
+  $ git log JOSH_HEAD --graph --pretty=%s
+  * add file3
   * add file2
   * add file1
 
-  $ git ls-tree --name-only -r refs/josh/filter/master 
+  $ git ls-tree --name-only -r JOSH_HEAD 
   c/file1
   c/file2
+  c/file3
+
+  $ josh-filter master c=:hide=sub1
+
+  $ git log JOSH_HEAD --graph --pretty=%s
+  * add some_other_file
+  * add some_file
+  * root
+
+  $ git ls-tree --name-only -r JOSH_HEAD 
+  c/some_file
+  c/some_other_file
+
+  $ josh-filter JOSH_HEAD :prefix=x
+
+  $ git ls-tree --name-only -r JOSH_HEAD
+  x/c/some_file
+  x/c/some_other_file
+
+  $ git ls-tree --name-only -r JOSH_HEAD~1
+  x/c/some_file
+
+  $ git ls-tree --name-only -r JOSH_HEAD~2
+
+Make sure that even with prefix applied we get a proper empty tree here
+  $ git show --format=raw JOSH_HEAD~2 | grep tree
+  tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904

--- a/tests/filter/file.t
+++ b/tests/filter/file.t
@@ -85,10 +85,8 @@
   $ git read-tree HEAD josh/filter/libs/master josh/filter/libs/foo
   $ git commit -m "sync"
   [master *] sync (glob)
-   5 files changed, 11 insertions(+)
-   create mode 100644 a/b/.joshinfo
+   3 files changed, 3 insertions(+)
    create mode 100644 a/b/file3
-   create mode 100644 c/.joshinfo
    create mode 100644 c/file1
    create mode 100644 c/file2
   $ git reset --hard
@@ -110,16 +108,12 @@
   * initial
 
   $ cat c/.joshinfo
-  commit: * (glob)
-  filter: :/sub1
-  src: libs/master
-  tree: * (glob)
+  cat: c/.joshinfo: No such file or directory
+  [1]
 
   $ cat a/b/.joshinfo
-  commit: * (glob)
-  filter: :/sub2
-  src: libs/foo
-  tree: * (glob)
+  cat: a/b/.joshinfo: No such file or directory
+  [1]
 
 $ git show libs/master | grep $(cat c/.joshinfo | grep commit | sed 's/commit: //')
 commit * (glob)

--- a/tests/filter/submodule.t
+++ b/tests/filter/submodule.t
@@ -26,12 +26,8 @@
 
   $ josh-filter master --update refs/josh/filter/master :/libs
   $ git ls-tree --name-only -r refs/josh/filter/master 
-  fatal: Not a valid object name refs/josh/filter/master
-  [128]
   $ josh-filter master --update refs/josh/filter/master c=:/libs
   $ git ls-tree --name-only -r refs/josh/filter/master 
-  fatal: Not a valid object name refs/josh/filter/master
-  [128]
 
 $ git log refs/josh/filter/master --graph --pretty=%s
 * add file2

--- a/tests/filter/submodule.t
+++ b/tests/filter/submodule.t
@@ -30,6 +30,8 @@
   [128]
   $ josh-filter master --update refs/josh/filter/master c=:/libs
   $ git ls-tree --name-only -r refs/josh/filter/master 
+  fatal: Not a valid object name refs/josh/filter/master
+  [128]
 
 $ git log refs/josh/filter/master --graph --pretty=%s
 * add file2

--- a/tests/filter/unknown_filter.t
+++ b/tests/filter/unknown_filter.t
@@ -22,6 +22,8 @@
   * add files
 
   $ josh-filter master --update refs/josh/filtered :nosuch=filter
+  ERROR: JoshError("invalid filter")
+  [1]
 
   $ git ls-tree --name-only -r refs/josh/filtered
   fatal: Not a valid object name refs/josh/filtered

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -1,0 +1,42 @@
+  $ export PATH=${TESTDIR}/../../target/debug/:${PATH}
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ git add sub1
+  $ git commit -m "add file1" 1> /dev/null
+
+  $ mkdir -p sub2/subsub
+  $ echo contents1 > sub2/subsub/file2
+  $ git add sub2
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ mkdir ws
+  $ cat > ws/workspace.josh <<EOF
+  > :/sub1:glob=file1
+  > sub2/subsub
+  > EOF
+  $ git add ws
+  $ git commit -m "add ws" 1> /dev/null
+
+  $ josh-filter master --update refs/josh/master :workspace=ws
+
+  $ git log --graph --pretty=%s refs/josh/master
+  * add ws
+  * add file2
+  * add file1
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ tree
+  .
+  |-- file1
+  |-- sub2
+  |   `-- subsub
+  |       `-- file2
+  `-- workspace.josh
+  
+  2 directories, 3 files

--- a/tests/filter/workspace_trailing_slash.t
+++ b/tests/filter/workspace_trailing_slash.t
@@ -39,15 +39,23 @@
   $ git commit -m "add trailing slash" 1> /dev/null
 
   $ josh-filter master --update refs/josh/master :workspace=ws
-  ERROR: JoshError("converted Error { code: -1, klass: 14, message: \"failed to insert entry: invalid name for a tree entry - c/\" }")
-  [1]
 
   $ git log --graph --pretty=%s refs/josh/master
+  * add trailing slash
   * add ws
   * add file2
   * add file1
 
   $ git checkout -q refs/josh/master 1> /dev/null
+  $ tree
+  .
+  |-- workspace.josh
+  `-- ws
+      `-- c
+  
+  2 directories, 1 file
+
+  $ git checkout -q HEAD~1
   $ tree
   .
   |-- a
@@ -60,17 +68,4 @@
       `-- c
   
   5 directories, 3 files
-
-  $ git checkout -q HEAD~1
-  $ tree
-  .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- file1
-  `-- ws
-      `-- c
-  
-  5 directories, 2 files
 

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -1,0 +1,46 @@
+  $ export PATH=${TESTDIR}/../../target/debug/:${PATH}
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ echo contents4 > sub1/file4
+  $ git add sub1
+  $ git commit -m "add file1" 1> /dev/null
+
+  $ mkdir -p sub2/subsub
+  $ echo contents1 > sub2/subsub/file2
+  $ git add sub2
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ mkdir ws
+  $ cat > ws/workspace.josh <<EOF
+  > :/sub1:glob=file1
+  > sub2/subsub
+  > a = :/sub1
+  > EOF
+  $ git add ws
+  $ git commit -m "add ws" 1> /dev/null
+
+  $ josh-filter master --update refs/josh/master :workspace=ws
+
+  $ git log --graph --pretty=%s refs/josh/master
+  * add ws
+  * add file2
+  * add file1
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ tree
+  .
+  |-- a
+  |   `-- file4
+  |-- file1
+  |-- sub2
+  |   `-- subsub
+  |       `-- file2
+  `-- workspace.josh
+  
+  3 directories, 4 files

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -104,17 +104,23 @@
   * add workspace
 
 
-  $ git push
-  remote: josh-proxy        
-  remote: response from upstream:        
-  remote:  converted Error { code: -1, klass: 14, message: "failed to insert entry: invalid name for a tree entry - a/" }        
-  remote: 
-  remote: 
-  remote: error: hook declined to update refs/heads/master        
+  $ git push 2>&1 >/dev/null | sed -e 's/[ ]*$//g'
+  remote: josh-proxy
+  remote: response from upstream:
+  remote:
+  remote: Can't apply "mod workspace" (*) (glob)
+  remote: Invalid workspace:
+  remote: ----
+  remote: a/ = :/sub1
+  remote:
+  remote: ----
+  remote:
+  remote:
+  remote: error: hook declined to update refs/heads/master
   To http://localhost:8002/real_repo.git:workspace=ws.git
    ! [remote rejected] master -> master (hook declined)
   error: failed to push some refs to 'http://localhost:8002/real_repo.git:workspace=ws.git'
-  [1]
+
 
   $ cd ${TESTTMP}/ws
   $ curl -s http://localhost:8002/flush

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -87,8 +87,25 @@
   $ git pull --rebase
   From http://localhost:8002/real_repo.git:workspace=ws
    * [new branch]      master     -> origin/master
-  \r (no-eol) (esc)
-  \x1b[KSuccessfully rebased and updated refs/heads/master. (esc)
+  Updating *..* (glob)
+  Fast-forward
+   a/b/file2      | 1 +
+   c/subsub/file1 | 1 +
+   2 files changed, 2 insertions(+)
+   create mode 100644 a/b/file2
+   create mode 100644 c/subsub/file1
+
+  $ tree
+  .
+  |-- a
+  |   `-- b
+  |       `-- file2
+  |-- c
+  |   `-- subsub
+  |       `-- file1
+  `-- workspace.josh
+  
+  4 directories, 3 files
 
   $ git log --graph --pretty=%s
   * Merge from :workspace=ws


### PR DESCRIPTION
The old implementation used repo.merge_trees which
is pretty slow.
Also rework error handling and reporting regarding
parsing errors in filter specs and workspace files.