### PR TITLE
Rework josh documentation

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -2,38 +2,97 @@
 History filtering
 =================
 
-`josh` operates by transforming commits by applying one or more `filters` to them.
-As any commit in `git` represents not just a single point in time but also it's whole
-history, applying a `filter` to a commit produces an entire new history.
-The result of a `filter` is a normal git commit and therefore can be filtered again,
+Josh transforms commits by applying one or more filters to them. As any
+commit in git represents not just a single point in time but also its entire
+history, applying a filter to a commit produces an entirely new history.
+The result of a filter is a normal git commit and therefore can be filtered again,
 making filters chainable.
 
 Syntax
 ------
 
-Filters are specified as::
+Filters are generally specified as::
 
     :filter=parameter
 
-And chained::
+And chained via colons::
 
     :filter1=parameter1:filter2=parameter2
 
-The only exception is the subdirectory filter ``:/`` it does not have a
-spelled out name and also no ``=`` in front of it's parameter. It can
-also be chained without the ``:``. Therefore ``:/a/b/c`` is exactly
-the same as ``:/a:/b:/c``.
+The only exception is the subdirectory filter ``:/``. It does not have a written name
+in the syntax and also no ``=`` in front of its parameter. It can also be chained
+without the ``:``. Therefore ``:/a/b/c`` is exactly the same as ``:/a:/b:/c``.
 
-Available filters:
+Available filters
+-----------------
 
 ``:/a``
-    Only take the selected subdirectory from the commits tree and
-    make it the root of the filtered commit
+    Take only the selected subdirectory from the commits tree and make it the root
+    of the filtered commit
 
 ``:prefix=a``
-    Take the whole original tree and move it into the subdirectory ``a``
+    Take the entire original tree and move it into subdirectory ``a``
 
 ``:workspace=a``
-    The same as ``:/a`` but also looks for a workspace file and add extra
+    The same as ``:/a`` but also looks for a workspace file and adds extra
     paths to the filtered tree.
     (see :doc:`workspace`)
+
+Repository naming
+-----------------
+
+By default, a git URL is used to point to the remote repository to download `and also` to dictate
+how the local repository shall be named.  It's important to learn that the last name in the URL is
+what the local git client will name the new, local repository. For example::
+
+    $ git clone http://localhost:8000/esrlabs/josh.git:/docs.git
+
+will create the new repository at directory ``docs``, as ``docs.git`` is the last name in the URL.
+
+By default, this leads to rather odd-looking repositories when the ``prefix`` filter is the final
+filter of a URL::
+
+    $ git clone http://localhost:8000/esrlabs/josh.git:/docs:prefix=josh-docs.git
+
+This will still clone just the josh documentation, but the final directory structure will look like
+this::
+
+    - prefix=josh-docs
+      - josh-docs
+        - <docs>
+
+Having the root repository directory name be the fully-specified filter is most likely not what was
+intended. This results from git's reuse and repurposing of the remote URL, as ``prefix=josh-docs``
+is the final name in the URL. With no other alternatives, this gets used for the repository name.
+
+To explicitly specify a repository name, provide the desired name after the URL when cloning a new
+repository::
+
+    $ git clone http://localhost:8000/esrlabs/josh.git:/docs:prefix=josh-docs.git my-repo
+
+Filter order matters
+--------------------
+
+Filters are applied in the left-to-right order they are given in the URL, and they are `not`
+commutative.
+
+For example, this (familiar) command will check out just the josh documentation, and store it in a
+subdirectory named ``josh-docs``::
+
+    $ git clone http://localhost:8000/esrlabs/josh.git:/docs:prefix=josh-docs.git
+
+However, `this` command will exit with the error that an empty reply was received from the server::
+
+    $ git clone http://localhost:8000/esrlabs/josh.git:prefix=josh-docs:/docs.git
+
+What's happening in the latter command is that because the prefix filter is applied first, the
+entire ``josh`` repository already lives within the ``josh-docs`` directory, as it was just
+transformed to exist there. Thus, to still get the docs, the command would need to be::
+
+    $ git clone http://localhost:8000/esrlabs/josh.git:prefix=josh-docs:/josh-docs/docs.git
+
+which will contain the josh documentation at the base of the repository. We've lost the prefix, what
+gives?? Because the original git tree was already transformed, and then the subdirectory filter
+was applied to pull documentation from ``josh-docs/docs``, the prefix is gone - it was filtered out
+again by the subdirectory filter. Thus, the order in which filters are provided is crucial, as each
+filter further transforms the latest transformation of the tree.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,11 +10,10 @@ Welcome to Josh's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   filters
-   cli
    proxy
+   filters
    workspace
-
+   cli
 
 
 Indices and tables

--- a/docs/proxy.rst
+++ b/docs/proxy.rst
@@ -2,25 +2,39 @@
 josh-proxy
 ==========
 
-Josh provides a http proxy server that can be used with any git hosting service that supports
-the http transfer protocol.
+Josh provides an HTTP proxy server that can be used with any git hosting service which communicates
+via HTTP.
 
-It needs the url of the upstream server and a local directory to store it's data.
-Optionally a port to listen on can be specified::
+It needs the URL of the upstream server and a local directory to store its data.
+Optionally, a port to listen on can be specified. For example, running a local ``josh-proxy``
+instance for github.com on port 8000::
 
-    $ josh-proxy --local=/tmp/josh --remote=https://github.com& --port=8000
+    $ josh-proxy --local=/tmp/josh --remote=https://github.com --port=8000
 
-Will run a proxy for github.com.
-
-Url syntax
-----------
-
-Urls for filtered repositories are constructed by appending the filter specification to the
-original path on the upstream host::
+For a first example of how to make use of josh, just the josh documentation can be checked out as
+its own repository via this command::
 
     $ git clone http://localhost:8000/esrlabs/josh.git:/docs.git
 
-Will clone a repository with just the documentation of josh itself.
+.. note::
 
-Note that this url needs to contain the `.git` suffix two times:
-Once after the original path and once more after the filter spec.
+    This URL needs to contain the `.git` suffix twice: once after the original path and once more
+    after the filter spec.
+
+URL syntax and breakdown
+------------------------
+
+This is the URL of a ``josh-proxy`` instance::
+
+    http://localhost:8000
+
+This is the repository location on the upstream host on which to perform the filter operations::
+
+    /esrlabs/josh.git
+
+This is the set of filter operations to perform::
+
+    :/docs.git
+
+Much more information on the available filters and the syntax of all filters is covered in detail in
+the :doc:`filters` section.

--- a/docs/workspace.rst
+++ b/docs/workspace.rst
@@ -2,20 +2,20 @@
 Working with workspaces
 =======================
 
-For the sake of this examples we will assume a josh instance is running and serving a repo on
+For the sake of this example we will assume a josh instance is running and serving a repo on
 ``http://josh/world.git`` with some shared code in ``shared``.
 
 Create a new workspace
 ----------------------
 
-To create a new workspace in the path ``ws/hello`` simplily clone it as if it already exists::
+To create a new workspace in the path ``ws/hello`` simply clone it as if it already exists::
 
     $ git clone http://josh/world.git:workspace=ws/hello.git
 
 ``git`` will report that you appear to have cloned an empty repository if that path does not
-exist yet.
-If you don't get this message it means, that the path already exists in the repo but may
-not have configured any path mappings yet.
+yet exist.
+If you don't get this message it means that the path already exists in the repo but may
+not yet have configured any path mappings.
 
 The next step is to add some path mapping to the ``workspace.josh`` file in the root of the
 workspace::


### PR DESCRIPTION
Reorder documentation to direct newcomers to the best introductory information first.

Rework proxy documentation to (hopefully) better explain how the josh-proxy works and the syntax of the URLs that users will need to write to use the proxy.

Add to the filters documentation to explain the caveats of repository naming and importance of filter order to teach newcomers how to explicitly name their repositories, and also why filter order matters so much.