### PR TITLE
cs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check format
       run: cargo fmt -- --check
+    - name: Run Rust tests
+      run: cargo test
     - name: Configure environment
       run: |
         export CARGO_TARGET_DIR=`pwd`/target

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::collections::HashMap;
 
-const VERSION: u64 = 4;
+const VERSION: u64 = 5;
 
 lazy_static! {
     static ref DB: std::sync::Mutex<Option<sled::Db>> =

--- a/tests/filter/pretty_print.t
+++ b/tests/filter/pretty_print.t
@@ -182,3 +182,22 @@
       ::subsub1/
       ::subsub2/
   ]
+
+Subdir only filters should not reorder filters that share a prefix
+  $ cat > f <<EOF
+  > a/subsub1 = :/sub1/subsub1
+  > :/x/subsub2
+  > EOF
+
+  $ josh-filter -p --file f
+  a/subsub1 = :/sub1/subsub1
+  :/x/subsub2
+
+  $ cat > f <<EOF
+  > :/x/subsub2
+  > a/subsub1 = :/sub1/subsub1
+  > EOF
+
+  $ josh-filter -p --file f
+  :/x/subsub2
+  a/subsub1 = :/sub1/subsub1


### PR DESCRIPTION
This fixed an issue where pushing through workspace
does not work correctly:
The workspace root was sorted to the back and then
reversed first, resulting in all mapped files being
moved to the workspace dir.