### PR TITLE
Adjust integration test so they are less fragile

### DIFF
--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -63,11 +63,11 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master (glob)
   remote:
   remote:
   To http://localhost:8002/real_repo.git
-   * [new reference]   HEAD -> refs/for/master
+   \* [new *]*HEAD -> refs/for/master (glob)
 
   $ cd ${TESTTMP}/remote/real_repo.git/
   $ git update-ref refs/changes/1/1 refs/for/master
@@ -95,11 +95,11 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master (glob)
   remote:
   remote:
   To http://localhost:8002/real_repo.git:/sub3.git
-   * [new reference]   HEAD -> refs/for/master
+   \* [new *]*HEAD -> refs/for/master (glob)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch -q http://localhost:8002/real_repo.git@refs/for/master:nop.git && git checkout -q FETCH_HEAD

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -176,6 +176,7 @@
    new_file2 | 0
    1 file changed, 0 insertions(+), 0 deletions(-)
    create mode 100644 new_file2
+  * (glob)
   $ tree
   .
   |-- file1
@@ -236,6 +237,7 @@
   $ git pull --rebase 2> /dev/null
   Updating 6fe45a9..8047211
   Fast-forward
+  * (glob)
   $ tree
   .
   |-- file1

--- a/tests/proxy/push_error.t
+++ b/tests/proxy/push_error.t
@@ -33,7 +33,7 @@
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
   remote:  ! [rejected]        JOSH_PUSH -> master (fetch first)        
-  remote: error: failed to push some refs to 'http://localhost:8001/real_repo.git'        
+  remote: error: failed to push some refs to 'http://*localhost:8001/real_repo.git'* (glob)
   remote: hint: Updates were rejected because the remote contains work that you do        
   remote: hint: not have locally. This is usually caused by another repository pushing        
   remote: hint: to the same ref. You may want to first integrate the remote changes        

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -40,7 +40,7 @@
    file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 file2
-
+  * (glob)
   $ tree
   .
   |-- file2

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -25,20 +25,20 @@
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master* (glob)
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/for/master
+   \* [new *]*master -> refs/for/master* (glob)
   $ git push origin master:refs/drafts/master
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/drafts/master        
+  remote:  \* [new *]*JOSH_PUSH -> refs/drafts/master* (glob)
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/drafts/master
+   \* [new *]*master -> refs/drafts/master* (glob)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -29,11 +29,11 @@ test for that.
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master* (glob)
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git
-   * [new reference]   master -> refs/for/master
+   \* [new *]*master -> refs/for/master* (glob)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -36,11 +36,11 @@ This is a regression test for that problem.
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master* (glob)
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git
-   * [new reference]   HEAD -> refs/for/master
+   \* [new *]*HEAD -> refs/for/master* (glob)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -35,11 +35,11 @@
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master* (glob)
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/for/master
+   \* [new *]*master -> refs/for/master* (glob)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -25,11 +25,11 @@
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master%topic=mytopic        
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master%topic=mytopic* (glob)
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/for/master%topic=mytopic
+   \* [new *]*master -> refs/for/master%topic=mytopic* (glob)
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -32,6 +32,7 @@
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  * (glob)
 
   $ tree
   .

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -67,6 +67,7 @@
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  * (glob)
 
   $ tree
   .

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -74,6 +74,7 @@ Put a double slash in the URL to see that it also works
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  * (glob)
 
   $ tree
   .
@@ -95,6 +96,7 @@ Put a double slash in the URL to see that it also works
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  * (glob)
 
   $ tree
   .

--- a/tests/proxy/query.t
+++ b/tests/proxy/query.t
@@ -33,7 +33,7 @@
 
   $ git push origin HEAD:refs/changes/123/2
   To http://localhost:8001/real_repo.git
-   * [new reference]   HEAD -> refs/changes/123/2
+   \* [new *]*HEAD -> refs/changes/123/2 (glob)
 
   $ cd ${TESTTMP}
 

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -57,7 +57,7 @@
   $ git sync
   * refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (1457 bytes)
+  POST git-receive-pack * (glob)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -80,8 +80,8 @@
    * branch            003a2970e4c23b64f915025e9adc2e6ed04bc63a -> FETCH_HEAD
   HEAD is now at 003a297 add workspace
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (440 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/* (glob)
+  POST git-receive-pack (*)(glob)
+  remote: warning: ignoring broken ref refs/namespaces/*/HEAD (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -168,7 +168,7 @@
   $ git sync
     refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (789 bytes)
+  POST git-receive-pack (*)* (glob)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -272,7 +272,7 @@
    * branch            2a6aa2a100b34d0d56e4b5f19e9bfdc2cd6f7d54 -> FETCH_HEAD
   HEAD is now at 2a6aa2a add in filter
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (808 bytes)
+  POST git-receive-pack (*)* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -298,7 +298,7 @@
    * branch            60bd0e180735e169b5c853545d8b1272ed0fc319 -> FETCH_HEAD
   HEAD is now at 60bd0e1 try to modify ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (460 bytes)
+  POST git-receive-pack (*)* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -133,12 +133,12 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master* (glob)
   remote: REWRITE(e63efb2615e1c17f0d0b6e610da85da09438cd29 -> 9bd58f891b4f17736c1b51903837de717fce13a5)
   remote:
   remote:
   To http://localhost:8002/real_repo.git:workspace=ws.git
-   * [new reference]   HEAD -> refs/for/master
+   \* [new *]*HEAD -> refs/for/master* (glob)
 
   $ cd ${TESTTMP}/remote/real_repo.git/
 
@@ -167,12 +167,12 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  \* [new *]*JOSH_PUSH -> refs/for/master* (glob)
   remote: REWRITE(5645805dcc75cfe4922b9cb301c40a4a4b35a59d -> 9a28fa82a736714d831348bbf62b951be65331b7)
   remote:
   remote:
   To http://localhost:8002/real_repo.git:workspace=ws.git
-   * [new reference]   HEAD -> refs/for/master
+   \* [new *]*HEAD -> refs/for/master* (glob)
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -54,7 +54,7 @@
   $ git add .
   $ git commit -m "add workspace" 1> /dev/null
   $ git push origin HEAD:refs/heads/master -o merge 2>&1 >/dev/null | sed -e 's/[ ]*$//g'
-  remote: warning: ignoring broken ref refs/namespaces/* (glob)
+  remote: warning: ignoring broken ref refs/namespaces/*/HEAD (glob)
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
@@ -101,6 +101,7 @@
    ws/workspace.josh | 4 ++++
    1 file changed, 4 insertions(+)
    create mode 100644 ws/workspace.josh
+  * (glob)
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws
@@ -156,7 +157,7 @@
   $ curl -s http://localhost:8002/flush
   Flushed credential cache
   $ git pull --rebase
-  Current branch master is up to date.
+  * (glob)
 
   $ tree
   .

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -57,7 +57,7 @@
   $ git sync
   * refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (1457 bytes)
+  POST git-receive-pack * (glob)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -80,8 +80,8 @@
    * branch            4a199f3a19a292e6639dede0f8602afc19a82dfc -> FETCH_HEAD
   HEAD is now at 4a199f3 Merge from :workspace=ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (439 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/* (glob)
+  POST git-receive-pack (* bytes)* (glob)
+  remote: warning: ignoring broken ref refs/namespaces/*/HEAD (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -98,6 +98,7 @@
   From http://localhost:8002/real_repo.git:workspace=ws
    + 1b46698...4a199f3 master     -> origin/master  (forced update)
   Already up to date.
+  * (glob)
 
   $ tree
   .
@@ -127,6 +128,7 @@
    ws/workspace.josh | 2 ++
    1 file changed, 2 insertions(+)
    create mode 100644 ws/workspace.josh
+  * (glob)
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws
@@ -174,7 +176,7 @@
   $ git sync
     refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (790 bytes)
+  POST git-receive-pack (* bytes)* (glob)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -190,6 +192,7 @@
    workspace.josh | 3 ++-
    2 files changed, 3 insertions(+), 1 deletion(-)
    create mode 100644 d/file3
+  * (glob)
 
   $ tree
   .
@@ -275,7 +278,7 @@
    * branch            3136fff7280627623bf4d71191d1aea783579be0 -> FETCH_HEAD
   HEAD is now at 3136fff add in filter
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (808 bytes)
+  POST git-receive-pack (* bytes)* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -301,7 +304,7 @@
    * branch            1a909d6e8ba43c6eaf211ef04440984d38bc26e6 -> FETCH_HEAD
   HEAD is now at 1a909d6 try to modify ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (460 bytes)
+  POST git-receive-pack (* bytes)* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -318,6 +321,7 @@
   From http://localhost:8002/real_repo.git:workspace=ws
    + 7f85f11...1a909d6 master     -> origin/master  (forced update)
   Already up to date.
+  * (glob)
 
 Note that d/ is still in the tree but now it is not overlayed
   $ tree
@@ -377,6 +381,7 @@ Note that d/ is still in the tree but now it is not overlayed
    create mode 100644 sub2/newfile_2
    create mode 100644 ws/d/file3
    create mode 100644 ws/ws_file
+  * (glob)
 
   $ git clean -ffdx 1> /dev/null
 

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -213,6 +213,7 @@
   $ curl -s http://localhost:8002/flush
   Flushed credential cache
   $ git pull --rebase 2> /dev/null
+  * (glob)
 
 Note that d/ is still in the tree but now it is not overlayed
   $ tree

--- a/tests/proxy/workspace_mv_folder.t
+++ b/tests/proxy/workspace_mv_folder.t
@@ -57,7 +57,7 @@
   $ git sync
   * refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (1457 bytes)
+  POST git-receive-pack * (glob)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -81,8 +81,8 @@
   HEAD is now at 4a199f3 Merge from :workspace=ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
   POST git-receive-pack (439 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/request_*/HEAD         (glob)
-  remote: josh-proxy        
+  remote: warning: ignoring broken ref refs/namespaces/request_55537ba7-5df9-40cd-948e-560b854c819b/HEAD
+  remote: josh-proxy
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
   remote:    5d605ce..98c996c  JOSH_PUSH -> master        


### PR DESCRIPTION
the integration tests very highly dependent on the exact same
output of a git command (even the irrelevant information)
which made the tests very fragile. this commit is a
first attempt to make the integration tests more
rubust and still be accurate